### PR TITLE
Make SQL pipeline resumable.

### DIFF
--- a/pipelines/sql_database/source.py
+++ b/pipelines/sql_database/source.py
@@ -1,24 +1,89 @@
-from typing import List, Iterator, Dict, Any, Optional
+from typing import List, Iterator, Dict, Any, Optional, Tuple, Union, Mapping, cast, TypedDict
+from collections import defaultdict
 
 import dlt
 from dlt.extract.source import DltResource
 from dlt.common import json
 
-from sqlalchemy import create_engine, MetaData, Table
+from sqlalchemy import create_engine, MetaData, Table, Executable, Column, tuple_
 from sqlalchemy.engine import Engine, Connection
 
 
-def table_rows(engine: Engine, table: Table) -> Iterator[Dict[str, Any]]:
+class CursorState(TypedDict):
+    last_value: Any
+    loaded_ids: List[Any]
+
+
+def _get_cursor_state(table_name: str, cursor_column: str) -> CursorState:
+    """Get the last loaded value of the table's cursor column from state.
+    """
+    states = dlt.state().setdefault('incremental', {})
+    table_state = states.setdefault(table_name, {})
+    cursor_state = table_state.setdefault(cursor_column, {'last_value': None, 'loaded_ids': []})
+    return cast(CursorState, cursor_state)
+
+
+def _set_last_value(table_name: str, cursor_column: str, value: Any, loaded_id: Any) -> None:
+    cursor_state = _get_cursor_state(table_name, cursor_column)
+    current_val = cursor_state['last_value']
+    if current_val != value:
+        cursor_state['last_value'] = value
+        cursor_state['loaded_ids'] = []
+    if loaded_id is not None:
+        cursor_state['loaded_ids'].append(loaded_id)
+
+
+def _make_query(table: Table, cursor_column: Optional[str], unique_column: Optional[str]) -> Tuple[Executable, Optional[Column[Any]], Optional[Column[Any]]]:
+    """Make the SQL query object to select from table.
+    Returns a tuple with the query and optionally the cursor column as `sqlalchemy.Column` object
+    """
+    query = table.select()
+    if not cursor_column:
+        return query, None, None
+    cursor_col = table.c.get(cursor_column)
+    if cursor_col is None:
+        # Cursor column doesn't exist in table
+        # TODO: Should this print a warning or exception?
+        return query, None, None
+    query = query.order_by(cursor_col)
+    cursor_state = _get_cursor_state(table.name, cursor_column)
+    last_value = cursor_state['last_value']
+    loaded_ids = cursor_state['loaded_ids']
+    unique_col = table.c.get(unique_column)
+    if last_value is None:
+        return query, cursor_col, unique_col
+    query = query.where(cursor_col >= last_value)
+    if not not loaded_ids and unique_col is not None:
+        query = query.where(tuple_(cursor_col, unique_col).notin_(
+            [(last_value, lid) for lid in loaded_ids]
+        ))
+    return query, cursor_col, unique_col
+
+
+def table_rows(
+    engine: Engine,
+    table: Table,
+    cursor_column: Optional[str] = None,
+    unique_column: Optional[str] = None
+) -> Iterator[Dict[str, Any]]:
     """Yields rows from the given database table.
 
     :param engine: An `sqlalchemy.engine.Engine` instance configured for the database
     :param table: The table to load data from
+    :param cursor_column: Optional column name to use as cursor for resumeable loading
+    :param unique_column: Optional column that uniquely identifies a row in the table for resumeable loading
     """
+    query, cursor, unique = _make_query(table, cursor_column, unique_column)
+
     conn: Connection
     with engine.connect() as conn:
-        with conn.execution_options(yield_per=1000).execute(table.select()) as result:
+        with conn.execution_options(yield_per=1000).execute(query) as result:
             for partition in result.partitions():  # type: ignore
                 for row in partition:
+                    if cursor is not None:
+                        _set_last_value(
+                            table.name, cursor_column, row._mapping[cursor], row._mapping.get(unique)
+                        )
                     yield dict(row._mapping)
 
 
@@ -27,7 +92,7 @@ def sql_database(
     database_url: str = dlt.secrets.value,
     schema: Optional[str] = dlt.config.value,
     table_names: Optional[List[str]] = dlt.config.value,
-    write_disposition: str = 'replace'
+    write_disposition: str = 'replace',
 ) -> List[DltResource]:
     """A dlt source which loads data from an SQL database using SQLAlchemy.
     Resources are automatically created for each table in the schema or from the given list of tables.

--- a/pipelines/sql_database_pipeline.py
+++ b/pipelines/sql_database_pipeline.py
@@ -7,8 +7,8 @@ from pipelines.sql_database import sql_database
 if __name__ == '__main__':
     pipeline = dlt.pipeline(
         dataset_name='sql_database_data',
-        destination='bigquery',
-        full_refresh=False
+        full_refresh=False,
+        restore_from_destination=True,
     )
     data = sql_database()
     info = pipeline.run(data)


### PR DESCRIPTION
I'm experimenting with making the SQL pipeline resumable, so it only reads rows not included in the previous run.  https://github.com/dlt-hub/pipelines/issues/10

Works by setting a `cursor_column` and optionally also `unique_column` (could be pk or some other unique field) in config, e.g. `config.toml`

```toml
[sources.some_table_name]
cursor_column = "updated_at"
unique_column = "id"
```

In dlt.state I store the last value of the cursor column and all unique ids for rows with that same cursor value.  
Good for the case where e.g. cursor is a timestamp for last update, then the unique column makes sure we don't miss rows in case of updates with same timestamp without having to store id of every row loaded in `dlt.state`.

For subsequent runs of the pipeline it generates queries like this to filter out previously loaded:

```sql
SELECT * FROM table_name
WHERE updated_at >= '2023-02-18T01:02:03Z'
AND (updated_at, id) NOT IN (('2023-02-18T01:02:03Z', 1), ('2023-02-18T01:02:03Z', 2), ('2023-02-18T01:02:03Z', 3))
ORDER BY updated_at;
```