### PR TITLE
Map pipedrive custom field enum values to labels

### DIFF
--- a/pipelines/pipedrive/__init__.py
+++ b/pipelines/pipedrive/__init__.py
@@ -162,10 +162,13 @@ def create_state(pipedrive_api_key: str) -> Iterator[Dict[str, Any]]:
     yield custom_fields_mapping
 
 
-@dlt.transformer(name='custom_fields_mapping', write_disposition='replace')
+@dlt.transformer(name='custom_fields_mapping', write_disposition='replace', columns={"options": {"data_type": "complex"}})
 def parsed_mapping(custom_fields_mapping: Dict[str, Any]) -> Optional[Iterator[List[Dict[str, str]]]]:
     """
     Parses and yields custom fields' mapping in order to be stored in destiny by dlt
     """
     for endpoint, data_item_mapping in custom_fields_mapping.items():
-        yield [{'endpoint': endpoint, 'hash_string': hash_string, 'name': names['name'], 'normalized_name': names['normalized_name']} for hash_string, names in data_item_mapping.items()]
+        yield [{
+            'endpoint': endpoint, 'hash_string': hash_string, 'name': names['name'],
+            'normalized_name': names['normalized_name'], 'options': names['options'], 'field_type': names['field_type']
+        } for hash_string, names in data_item_mapping.items()]

--- a/pipelines/pipedrive/custom_fields_munger.py
+++ b/pipelines/pipedrive/custom_fields_munger.py
@@ -1,8 +1,15 @@
-from typing import Any, Dict, Iterable, Iterator
+from typing import Any, Dict, Iterable, Iterator, TypedDict, Optional
 
 import dlt
 
 from .typing import TDataPage
+
+
+
+class TFieldMapping(TypedDict):
+    name: str
+    normalized_name: str
+    options: Optional[Dict[str, str]]
 
 
 def update_fields_mapping(new_fields_mapping: TDataPage, existing_fields_mapping: Dict[str, Any]) -> Dict[str, Any]:
@@ -17,35 +24,56 @@ def update_fields_mapping(new_fields_mapping: TDataPage, existing_fields_mapping
             # We assume that pipedrive's hash strings are meant to be an univoque representation of custom fields' name, so dlt's state shouldn't be updated while those values
             # remain unchanged
             # First of all, we search on and update dlt's state
-            if existing_fields_mapping:
-                if data_item['key'] not in existing_fields_mapping:
-                    data_item_mapping = _normalize_map(data_item)
-                    existing_fields_mapping.update(data_item_mapping)
-            else:
-                existing_fields_mapping = _normalize_map(data_item)
+            existing_fields_mapping = _update_field(data_item, existing_fields_mapping)
             # We end up updating data with dlt's state
             # data_item['key'] = existing_fields_mapping[data_item['key']]['normalized_name']
     return existing_fields_mapping
 
 
-def _normalize_map(data_item: Dict[str, Any]) -> Dict[str, Dict[str, str]]:
+def _update_field(data_item: Dict[str, Any], existing_fields_mapping: Optional[Dict[str, TFieldMapping]]) -> Dict[str, TFieldMapping]:
+    """Create or update the given field's info the custom fields state
+    If the field hash already exists in the state from previous runs the name is not updated.
+    New enum options (if any) are appended to the state.
+    """
+    existing_fields_mapping = existing_fields_mapping or {}
+    key = data_item['key']
+    options = data_item.get('options', [])
+    new_options_map = {str(o['id']): o['label'] for o in options}
+    existing_field = existing_fields_mapping.get(key)
+    if not existing_field:
+        existing_fields_mapping[key] = dict(
+            name=data_item['name'],
+            normalized_name=_normalized_name(data_item['name']),
+            options=new_options_map
+        )
+        return existing_fields_mapping
+    existing_options = existing_field.get('options', {})
+    if not existing_options or existing_options == new_options_map:
+        existing_field['options'] = new_options_map
+        return existing_fields_mapping
+    # Add new enum options to the existing options array
+    # so that when option is renamed the original label remains valid
+    new_option_keys = set(new_options_map) - set(existing_options)
+    for key in new_option_keys:
+        existing_options[key] = new_options_map[key]
+    existing_field['options'] = existing_options
+    return existing_fields_mapping
+
+
+def _normalized_name(name: str) -> str:
     source_schema = dlt.current.source_schema()
-    normalized_name = data_item['name'].strip()  # remove leading and trailing spaces
-    normalized_name = source_schema.naming.normalize_identifier(normalized_name)
-    return {
-        data_item['key']: {
-            'name': data_item['name'],
-            'normalized_name': normalized_name
-            }
-    }
+    normalized_name = name.strip()  # remove leading and trailing spaces
+    return source_schema.naming.normalize_identifier(normalized_name)
 
 
 def rename_fields(data: TDataPage, fields_mapping: Dict[str, Any]) -> TDataPage:
     if not fields_mapping:
         return data
-    renames = [(hash_string, names["name"]) for hash_string, names in fields_mapping.items()]
     for data_item in data:
-        for hash_string, name in renames:
+        for hash_string, field in fields_mapping.items():
             if hash_string in data_item:
-                data_item[name] = data_item.pop(hash_string)
+                field_value = data_item.pop(hash_string)
+                # Get label instead of ID for enum fields
+                options_map = field.get('options', {})
+                data_item[field['name']] = options_map.get(field_value, field_value)
     return data

--- a/tests/pipedrive/test_pipedrive_pipeline.py
+++ b/tests/pipedrive/test_pipedrive_pipeline.py
@@ -55,7 +55,7 @@ def test_all_resources(destination_name: str) -> None:
 def test_custom_fields_munger(destination_name: str) -> None:
     pipeline = dlt.pipeline(pipeline_name='pipedrive', destination=destination_name, dataset_name='pipedrive_data', full_refresh=True)
 
-    load_info = pipeline.run(pipedrive_source().with_resources('persons', 'products', 'custom_fields_mapping'))
+    load_info = pipeline.run(pipedrive_source().with_resources('persons', 'products', 'deals', 'custom_fields_mapping'))
 
     print(load_info)
     assert_load_info(load_info)
@@ -100,8 +100,13 @@ def test_custom_fields_munger(destination_name: str) -> None:
     # Test set field is mapped in value table
     person_multiple_options_table = schema.get_table('persons__multiple_options')
     assert 'value' in person_multiple_options_table['columns']
-    query_string = raw_query_string.format(fields="value", table="persons__multiple_options", condition="abc") + " LIMIT 1"
+    query_string = raw_query_string.format(fields="value", table="persons__multiple_options", condition="value = 'abc'") + " LIMIT 1"
     assert_query_data(pipeline, query_string,  ["abc"])
+
+    # Test deal field label
+    condition = "value = 'label with, comma'"
+    query_string = raw_query_string.format(fields='value', table='deals__label', condition=condition) + " LIMIT 1"
+    assert_query_data(pipeline, query_string, ["label with, comma"])
 
     # test product custom fields data munging
 

--- a/tests/pipedrive/test_pipedrive_pipeline.py
+++ b/tests/pipedrive/test_pipedrive_pipeline.py
@@ -187,6 +187,7 @@ def test_update_fields_new_enum_field() -> None:
             'edit_flag': True,
             'name': 'custom_field_1',
             'key': 'random_hash_1',
+            'field_type': 'enum',
             'options': [{'id': 3, 'label': 'a'}, {'id': 4, 'label': 'b'}, {'id': 5, 'label': 'c'}]
         }
     ]
@@ -196,7 +197,10 @@ def test_update_fields_new_enum_field() -> None:
 
     assert result == {
         'random_hash_1': {
-            'name': 'custom_field_1', 'normalized_name': 'custom_field_1', 'options': {'3': 'a', '4': 'b', '5': 'c'}
+            'name': 'custom_field_1',
+            'normalized_name': 'custom_field_1',
+            'field_type': 'enum',
+            'options': {'3': 'a', '4': 'b', '5': 'c'}
         }
     }
 
@@ -212,6 +216,7 @@ def test_update_fields_add_enum_field_options() -> None:
             'edit_flag': True,
             'name': 'custom_field_1',
             'key': 'random_hash_1',
+            'field_type': 'enum',
             'options': [{'id': 3, 'label': 'a'}, {'id': 4, 'label': 'previously_b'}, {'id': 5, 'label': 'c'}, {'id': 7, 'label': 'd'}]
         }
     ]
@@ -226,10 +231,28 @@ def test_rename_fields_with_enum() -> None:
     data_item = {'random_hash_1': '42', 'id': 44, 'name': 'asdf'}
     mapping = {
         'random_hash_1': {
-            'name': 'custom_field_1', 'normalized_name': 'custom_field_1', 'options': {'3': 'a', '42': 'b', '5': 'c'}
+            'name': 'custom_field_1',
+            'normalized_name': 'custom_field_1',
+            'field_type': 'enum',
+            'options': {'3': 'a', '42': 'b', '5': 'c'}
         }
     }
 
     result = rename_fields([data_item], mapping)
 
     assert result == [{'custom_field_1': 'b', 'id': 44, 'name': 'asdf'}]
+
+def test_rename_fields_with_set() -> None:
+    data_item = {'random_hash_1': '42,44,23', 'id': 44, 'name': 'asdf'}
+    mapping = {
+        'random_hash_1': {
+            'name': 'custom_field_1',
+            'normalized_name': 'custom_field_1',
+            'field_type': 'set',
+            'options': {'44': 'a', '42': 'b', '522': 'c', '23': 'c'}
+        }
+    }
+
+    result = rename_fields([data_item], mapping)
+
+    assert result == [{'custom_field_1': 'b,a,c', 'id': 44, 'name': 'asdf'}]


### PR DESCRIPTION
# Tell us what you do here

- [x] improving, documenting, customizing existing pipeline (please link relevant issue)

Custom enum fields are now mapped to the string label instead of the ID of the enum value

# Relevant issue

fixes #119

# More PR info


TODO:
- [x] Add enum fields in test account and add to integration tests
- [x] Add unit tests for `update_fields_mapping` to test a) new field with options b) existing field with options added c) existing field with options renamed
- [x] Handle both "multiple choice" and "single choice" fields (`set` field in api will have multiple ids comma separated)
- [x] Map values for custom enum/set fields like "deals.labels" 