### PR TITLE
Sql database examples

### DIFF
--- a/pipelines/.dlt/example.secrets.toml
+++ b/pipelines/.dlt/example.secrets.toml
@@ -56,7 +56,12 @@ pipedrive_api_key="set me up!"
 
 # Example database for source in sql_database/source.py
 [sources.sql_database]
-database_url = "postgresql://my_user:my_password@localhost:5439/my_database"
+drivername = "mysql+pymysql"
+database = "Rfam"
+username = "rfamro"
+# password = ""
+host = "mysql-rfam-public.ebi.ac.uk"
+port = "4497"
 
 # not all these credentials are needed, you can choose between
 # email + password

--- a/pipelines/sql_database/sql_database.py
+++ b/pipelines/sql_database/sql_database.py
@@ -13,18 +13,25 @@ from .util import table_rows, engine_from_credentials, get_primary_key
 
 
 @configspec
-class SqlTableConfiguration(BaseConfiguration):
+class SqlDatabaseTableConfiguration(BaseConfiguration):
     incremental: Optional[dlt.sources.incremental] = None  # type: ignore[type-arg]
 
 
-@dlt.resource
+@configspec
+class SqlTableResourceConfiguration(BaseConfiguration):
+    credentials: ConnectionStringCredentials
+    table: str
+    incremental: Optional[dlt.sources.incremental] = None  # type: ignore[type-arg]
+    schema: Optional[str]
+
+
+@dlt.common.configuration.with_config(sections=('sources', 'sql_database'), spec=SqlTableResourceConfiguration)
 def sql_table(
     credentials: Union[ConnectionStringCredentials, Engine, str] = dlt.secrets.value,
     table: str = dlt.config.value,
     schema: Optional[str] = dlt.config.value,
     metadata: Optional[MetaData] = None,
     incremental: Optional[dlt.sources.incremental[Any]] = None,
-    write_disposition: TWriteDisposition = 'append'
 ) -> DltResource:
     """A dlt resource which loads data from an SQL database table using SQLAlchemy.
 
@@ -35,7 +42,6 @@ def sql_table(
     :param incremental: Option to enable incremental loading for the table. E.g. `incremental=dlt.source.incremental('updated_at', pendulum.parse('2022-01-01T00:00:00Z'))`
     :param write_disposition: Write disposition of the resource
     """
-
     engine = engine_from_credentials(credentials)
     engine.execution_options(stream_results=True)
     metadata = metadata or MetaData(schema=schema)
@@ -43,7 +49,7 @@ def sql_table(
     table_obj = Table(table, metadata, autoload_with=engine)
 
     return dlt.resource(
-        table_rows, name=table_obj.name, write_disposition=write_disposition, primary_key=get_primary_key(table_obj)
+        table_rows, name=table_obj.name, primary_key=get_primary_key(table_obj)
     )(engine, table_obj, incremental=incremental)
 
 
@@ -82,7 +88,7 @@ def sql_database(
             table_rows,
             name=table.name,
             primary_key=get_primary_key(table),
-            spec=SqlTableConfiguration,
+            spec=SqlDatabaseTableConfiguration,
         )(engine, table)
         for table in tables
     ]

--- a/pipelines/sql_database_pipeline.py
+++ b/pipelines/sql_database_pipeline.py
@@ -1,18 +1,89 @@
 from typing import List
 
 import dlt
+from dlt.sources.credentials import ConnectionStringCredentials
+from dlt.common import pendulum
 
-from sql_database import sql_database
+from sql_database import sql_database, sql_table
 
-if __name__ == '__main__':
-    pipeline = dlt.pipeline(
-        pipeline_name="sql_tables",
-        destination="bigquery",
-        dataset_name='sql_database_data',
-        full_refresh=False,
-    )
-    data = sql_database()
-    info = pipeline.run(data)
+
+def load_select_tables_from_database() -> None:
+    """Use the sql_database source to reflect an entire database schema and load select tables from it.
+
+    This example sources data from the public Rfam MySQL database.
+    """
+    # Create a pipeline
+    pipeline = dlt.pipeline(pipeline_name='rfam', destination='postgres', dataset_name='rfam_data')
+
+    # Credentials for the sample database.
+    # Note: It is recommended to configure credentials in `.dlt/secrets.toml` under `sources.sql_database.credentials`
+    credentials = ConnectionStringCredentials("mysql+pymysql://rfamro@mysql-rfam-public.ebi.ac.uk:4497/Rfam")
+
+    # Configure the source to load a few select tables incrementally
+    source_1 = sql_database(credentials).with_resources('family', 'clan')
+    # Add incremental config to the resources. "updated" is a timestamp column in these tables that gets used as a cursor
+    source_1.family.apply_hints(incremental=dlt.sources.incremental('updated'))
+    source_1.clan.apply_hints(incremental=dlt.sources.incremental('updated'))
+
+    # Run the pipeline. The merge write disposition merges existing rows in the destination by primary key
+    info = pipeline.run(source_1, write_disposition='merge')
+    print(info)
+
+    # Load some other tables with replace write disposition. This overwrites the existing tables in destination
+    source_2 = sql_database(credentials).with_resources('features', "author")
+    info = pipeline.run(source_2, write_disposition='replace')
+    print(info)
+
+    # Load a table incrementally with append write disposition
+    # this is good when a table only has new rows inserted, but not updated
+    source_3 = sql_database(credentials).with_resources('genome')
+    source_3.genome.apply_hints(incremental=dlt.sources.incremental('created'))
+
+    info = pipeline.run(source_3, write_disposition='append')
     print(info)
 
 
+def load_entire_database() -> None:
+    """Use the sql_database source to completely load all tables in a database"""
+    pipeline = dlt.pipeline(pipeline_name='rfam', destination='postgres', dataset_name='rfam_data')
+
+    # By default the sql_database source reflects all tables in the schema
+    # The database credentials are sourced from the `.dlt/secrets.toml` configuration
+    source = sql_database()
+
+    # Run the pipeline. For a large db this may take a while
+    info = pipeline.run(source, write_disposition="replace")
+    print(info)
+
+
+def load_standalone_table_resource() -> None:
+    """Load a few known tables with the standalone sql_table resource"""
+    pipeline = dlt.pipeline(pipeline_name='rfam_database', destination='postgres', dataset_name='rfam_data')
+
+    # Load a table incrementally starting at a given date
+    # Adding incremental via argument like this makes extraction more efficient
+    # as only rows newer than the start date are fetched from the table
+    family = sql_table(
+        table='family',
+        incremental=dlt.sources.incremental('updated', initial_value=pendulum.DateTime(2022, 1, 1, 0, 0, 0))
+    )
+
+    # Load all data from another table
+    genome = sql_table(table='genome')
+
+    # Run the resources together
+    info = pipeline.extract([family, genome], write_disposition='merge')
+    print(info)
+
+
+
+if __name__ == '__main__':
+    # Load selected tables with different settings
+    load_select_tables_from_database()
+
+    # Load tables with the standalone table resource
+    # load_standalone_table_resource()
+
+    # Load all tables from the database.
+    # Warning: The sample database is very large
+    # load_entire_database()

--- a/tests/sql_database/test_sql_database_pipeline.py
+++ b/tests/sql_database/test_sql_database_pipeline.py
@@ -92,16 +92,16 @@ def test_load_mysql_data_load(destination_name: str) -> None:
     assert "family" in database.resources
 
     # load a single table
-    family_table = sql_table(credentials="mysql+pymysql://rfamro@mysql-rfam-public.ebi.ac.uk:4497/Rfam", table='family', write_disposition="merge")
+    family_table = sql_table(credentials="mysql+pymysql://rfamro@mysql-rfam-public.ebi.ac.uk:4497/Rfam", table='family')
 
     pipeline = make_pipeline(destination_name)
-    load_info = pipeline.run(family_table)
+    load_info = pipeline.run(family_table, write_disposition='merge')
     assert_load_info(load_info)
     counts_1 = load_table_counts(pipeline, "family")
 
     # load again also with merge
-    family_table = sql_table(credentials="mysql+pymysql://rfamro@mysql-rfam-public.ebi.ac.uk:4497/Rfam", table='family', write_disposition="merge")
-    load_info = pipeline.run(family_table)
+    family_table = sql_table(credentials="mysql+pymysql://rfamro@mysql-rfam-public.ebi.ac.uk:4497/Rfam", table='family')
+    load_info = pipeline.run(family_table, write_disposition='merge')
     assert_load_info(load_info)
     counts_2 = load_table_counts(pipeline, "family")
     # no duplicates


### PR DESCRIPTION
# Tell us what you do here

- [x] improving, documenting, customizing existing pipeline (please link relevant issue)

Adds usage examples for the sqlalchemy pipeline.   
* Using the sql_database source in multiple configuration with explicit credentials
* sql_database source to load entire database
* Using the standalone resource to load some known tables

Changed the standalone table resource to be a normal function wrapped in `with_config`. The nested resource causes issues with the incremental wrapper

# Relevant issue

closes #75